### PR TITLE
feat(api): implementar CRUD de Schools

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 api_bp = Blueprint("api", __name__)
 
-from app.api import routes, errors
+from app.api import routes, errors, school_routes

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,0 +1,24 @@
+from marshmallow import fields, validate
+from app.extensions import ma
+from app.models.school import School
+from app.models.canteen import Canteen
+
+class SchoolSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = School
+        include_fk = True
+        load_instance = True
+
+    name = fields.String(required=True, validate=validate.Length(min=3, max=255))
+    cnpj = fields.String(required=True, validate=validate.Length(min=14, max=18))
+    address = fields.String(allow_none=True)
+    active = fields.Boolean(load_default=True)
+
+class CanteenSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Canteen
+        include_fk = True
+        load_instance = True
+
+    name = fields.String(required=True, validate=validate.Length(min=2, max=255))
+    active = fields.Boolean(load_default=True)

--- a/app/api/school_routes.py
+++ b/app/api/school_routes.py
@@ -1,0 +1,54 @@
+from flask import request, jsonify
+from app.api import api_bp
+from app.extensions import db
+from app.models.school import School
+from app.api.schemas import SchoolSchema
+
+school_schema = SchoolSchema()
+schools_schema = SchoolSchema(many=True)
+
+@api_bp.route("/schools", methods=["GET"])
+def get_schools():
+    """Retorna lista de todas as escolas."""
+    schools = School.query.all()
+    return jsonify(schools_schema.dump(schools)), 200
+
+@api_bp.route("/schools", methods=["POST"])
+def create_school():
+    """Cria uma nova escola."""
+    data = request.get_json()
+    try:
+        new_school = school_schema.load(data)
+        db.session.add(new_school)
+        db.session.commit()
+        return jsonify(school_schema.dump(new_school)), 201
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": "Falha ao criar escola", "message": str(e)}), 400
+
+@api_bp.route("/schools/<uuid:school_id>", methods=["GET"])
+def get_school(school_id):
+    """Pega detalhes de uma escola específica."""
+    school = School.query.get_or_404(school_id)
+    return jsonify(school_schema.dump(school)), 200
+
+@api_bp.route("/schools/<uuid:school_id>", methods=["PUT"])
+def update_school(school_id):
+    """Atualiza dados de uma escola."""
+    school = School.query.get_or_404(school_id)
+    data = request.get_json()
+    try:
+        updated_school = school_schema.load(data, instance=school, partial=True)
+        db.session.commit()
+        return jsonify(school_schema.dump(updated_school)), 200
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": "Falha ao atualizar escola", "message": str(e)}), 400
+
+@api_bp.route("/schools/<uuid:school_id>", methods=["DELETE"])
+def delete_school(school_id):
+    """Remove uma escola."""
+    school = School.query.get_or_404(school_id)
+    db.session.delete(school)
+    db.session.commit()
+    return jsonify({"message": "Escola removida com sucesso"}), 200


### PR DESCRIPTION
## Descrição

Implementa a primeira parte da gestão de tenants: CRUD de Escolas.

## Mudanças

- Schemas Marshmallow para validação.
- Rotas RESTful em `/api/v1/schools`.

Closes #45