### PR TITLE
feat(middleware): implementar Tenant Resolver

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,7 +26,13 @@ def create_app(config_name=None):
     celery_init_app(app)
 
     from app.api.errors import register_error_handlers
+    from app.utils.tenant_utils import resolve_tenant
+    
     register_error_handlers(app)
+    
+    @app.before_request
+    def handle_tenant():
+        resolve_tenant()
 
     # Registro de Blueprints
     from app.api import api_bp

--- a/app/utils/tenant_utils.py
+++ b/app/utils/tenant_utils.py
@@ -1,0 +1,28 @@
+from flask import g
+from flask_jwt_extended import get_jwt, verify_jwt_in_request
+from functools import wraps
+
+def get_current_tenant_id():
+    """Retorna o ID da cantina do contexto atual (flask.g)."""
+    return getattr(g, "canteen_id", None)
+
+def resolve_tenant():
+    """
+    Middleware (hook) para extrair o canteen_id do JWT.
+    Deve ser chamado em um before_request.
+    """
+    try:
+        # Verifica se há um JWT válido sem interromper a requisição se não houver
+        # (permitindo rotas públicas como login)
+        verify_jwt_in_request(optional=True)
+        
+        claims = get_jwt()
+        if claims:
+            g.canteen_id = claims.get("canteen_id")
+            g.user_role = claims.get("role")
+            g.user_id = claims.get("sub")
+    except Exception:
+        # Se falhar (ex: token inválido), g.canteen_id continua None
+        g.canteen_id = None
+        g.user_role = None
+        g.user_id = None


### PR DESCRIPTION
## Descrição

Implementa o middleware de resolução de tenant via JWT.

## Mudanças

- Hook `before_request` que injeta `canteen_id` no `flask.g`.
- Útil para filtragem automática de dados em sprints futuras.

Closes #50