### PR TITLE
feat(middleware): implementar decorators RBAC

### DIFF
--- a/app/api/school_routes.py
+++ b/app/api/school_routes.py
@@ -3,11 +3,13 @@ from app.api import api_bp
 from app.extensions import db
 from app.models.school import School
 from app.api.schemas import SchoolSchema
+from app.utils.tenant_utils import roles_required
 
 school_schema = SchoolSchema()
 schools_schema = SchoolSchema(many=True)
 
 @api_bp.route("/schools", methods=["GET"])
+@roles_required("ADMIN_MASTER")
 def get_schools():
     """Retorna lista de todas as escolas."""
     schools = School.query.all()

--- a/app/utils/tenant_utils.py
+++ b/app/utils/tenant_utils.py
@@ -6,6 +6,25 @@ def get_current_tenant_id():
     """Retorna o ID da cantina do contexto atual (flask.g)."""
     return getattr(g, "canteen_id", None)
 
+def roles_required(*roles):
+    """
+    Decorator para restringir acesso a determinadas roles.
+    Ex: @roles_required('ADMIN_MASTER', 'GESTOR')
+    """
+    def decorator(f):
+        @wraps(f)
+        @jwt_required()
+        def decorated_function(*args, **kwargs):
+            claims = get_jwt()
+            user_role = claims.get("role")
+            
+            if user_role not in roles:
+                return {"error": "Acesso negado", "message": f"Requer roles: {roles}"}, 403
+            
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator
+
 def resolve_tenant():
     """
     Middleware (hook) para extrair o canteen_id do JWT.


### PR DESCRIPTION
## Descrição

Finaliza a Sprint 1 com a implementação da autorização (RBAC).

## Mudanças

- Decorator `@roles_required` em `app/utils/tenant_utils.py`.
- Proteção inicial aplicada ao CRUD de Escolas.

Closes #51